### PR TITLE
Simulate price moves inside candle more accurately

### DIFF
--- a/src/backtest/backtest-order-execution.ts
+++ b/src/backtest/backtest-order-execution.ts
@@ -109,21 +109,28 @@ export function handleOrders(args: OrderHandlerArgs): AssetAndCash {
   const position = newTransactions.reduce(updatePosition, asset.position);
   const transactions = asset.transactions.concat(newTransactions);
 
-  const newTrade =
-    newTransactions.length && !position
-      ? convertToTrade({
-          symbol: asset.symbol,
-          entry: transactions[transactions.length - 2],
-          exit: transactions[transactions.length - 1],
-        })
-      : null;
+  const positionExited = newTransactions.length && !position;
+  const exitUpdates: Partial<AssetState> = positionExited
+    ? {
+        trades: asset.trades.concat(
+          convertToTrade({
+            symbol: asset.symbol,
+            entry: transactions[transactions.length - 2],
+            exit: transactions[transactions.length - 1],
+          })
+        ),
+        entryOrder: null,
+        stopLoss: null,
+        takeProfit: null,
+      }
+    : {};
 
   return {
     asset: {
       ...asset,
       position,
       transactions,
-      trades: newTrade ? asset.trades.concat(newTrade) : asset.trades,
+      ...exitUpdates,
     },
     cash,
   };

--- a/test/__snapshots__/backtest-order-execution.test.ts.snap
+++ b/test/__snapshots__/backtest-order-execution.test.ts.snap
@@ -1,0 +1,591 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`green candle: should fill entry 1`] = `
+{
+  "asset": {
+    "entryOrder": {
+      "price": 55,
+      "side": "sell",
+      "size": 1,
+      "type": "limit",
+    },
+    "position": {
+      "side": "short",
+      "size": 1,
+    },
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 55,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 154,
+}
+`;
+
+exports[`green candle: should fill entry and sl immediately 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": -2,
+        "entry": {
+          "commission": 1,
+          "price": 50,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 50,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "long",
+          "size": 1,
+        },
+        "relativeProfit": -0.04,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 50,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 50,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 98,
+}
+`;
+
+exports[`green candle: should fill entry at body, skip sl in body below entry, fill tp at high 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": 13,
+        "entry": {
+          "commission": 1,
+          "price": 55,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 70,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "long",
+          "size": 1,
+        },
+        "relativeProfit": 0.23636363636363636,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 55,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 70,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 113,
+}
+`;
+
+exports[`green candle: should fill entry at bottom tail, fill sl at bottom tail, skip tp at high 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": -7,
+        "entry": {
+          "commission": 1,
+          "price": 45,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 40,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "long",
+          "size": 1,
+        },
+        "relativeProfit": -0.15555555555555556,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 45,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 40,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 93,
+}
+`;
+
+exports[`green candle: should fill entry at bottom tail, skip sl below tail, fill tp at high 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": 28,
+        "entry": {
+          "commission": 1,
+          "price": 40,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 70,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "long",
+          "size": 1,
+        },
+        "relativeProfit": 0.7,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 40,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 70,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 128,
+}
+`;
+
+exports[`green candle: should fill short entry at body, skip tp in body below entry, fill sl at high 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": -17,
+        "entry": {
+          "commission": 1,
+          "price": 55,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 70,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "short",
+          "size": 1,
+        },
+        "relativeProfit": -0.3090909090909091,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 55,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 70,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 83,
+}
+`;
+
+exports[`red candle: should fill entry 1`] = `
+{
+  "asset": {
+    "entryOrder": {
+      "price": 45,
+      "side": "buy",
+      "size": 1,
+      "type": "limit",
+    },
+    "position": {
+      "side": "long",
+      "size": 1,
+    },
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 45,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 54,
+}
+`;
+
+exports[`red candle: should fill entry and sl immediately 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": -2,
+        "entry": {
+          "commission": 1,
+          "price": 50,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 50,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "short",
+          "size": 1,
+        },
+        "relativeProfit": -0.04,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 50,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 50,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 98,
+}
+`;
+
+exports[`red candle: should fill entry at body, skip sl in body above entry, fill tp at low 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": 13,
+        "entry": {
+          "commission": 1,
+          "price": 45,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 30,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "short",
+          "size": 1,
+        },
+        "relativeProfit": 0.28888888888888886,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 45,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 30,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 113,
+}
+`;
+
+exports[`red candle: should fill entry at top tail, fill sl at top tail, skip tp at low 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": -7,
+        "entry": {
+          "commission": 1,
+          "price": 55,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 60,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "short",
+          "size": 1,
+        },
+        "relativeProfit": -0.12727272727272726,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 55,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 60,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 93,
+}
+`;
+
+exports[`red candle: should fill entry at top tail, skip sl above tail, fill tp at low 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": 28,
+        "entry": {
+          "commission": 1,
+          "price": 60,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 30,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "short",
+          "size": 1,
+        },
+        "relativeProfit": 0.4666666666666667,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 60,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 30,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 128,
+}
+`;
+
+exports[`red candle: should fill long entry at body, skip tp in body above entry, fill sl at low 1`] = `
+{
+  "asset": {
+    "entryOrder": null,
+    "position": null,
+    "stopLoss": null,
+    "takeProfit": null,
+    "trades": [
+      {
+        "absoluteProfit": -17,
+        "entry": {
+          "commission": 1,
+          "price": 45,
+          "side": "buy",
+          "size": 1,
+          "time": 1,
+        },
+        "exit": {
+          "commission": 1,
+          "price": 30,
+          "side": "sell",
+          "size": 1,
+          "time": 1,
+        },
+        "position": {
+          "side": "long",
+          "size": 1,
+        },
+        "relativeProfit": -0.37777777777777777,
+        "symbol": "foo",
+      },
+    ],
+    "transactions": [
+      {
+        "commission": 1,
+        "price": 45,
+        "side": "buy",
+        "size": 1,
+        "time": 1,
+      },
+      {
+        "commission": 1,
+        "price": 30,
+        "side": "sell",
+        "size": 1,
+        "time": 1,
+      },
+    ],
+  },
+  "cash": 83,
+}
+`;

--- a/test/backtest-order-execution.test.ts
+++ b/test/backtest-order-execution.test.ts
@@ -1,0 +1,167 @@
+import { omit, pipe } from "remeda";
+import { AssetState, Candle } from "../src";
+import {
+  handleOrders,
+  OrderHandlerArgs,
+} from "../src/backtest/backtest-order-execution";
+
+type TestArgs = Partial<
+  Pick<AssetState, "position" | "entryOrder" | "stopLoss" | "takeProfit">
+> & { candle: Candle };
+
+function getArgs(args: TestArgs): OrderHandlerArgs {
+  const asset: AssetState = {
+    symbol: "foo",
+    series: [args.candle],
+    position: null,
+    entryOrder: null,
+    stopLoss: null,
+    takeProfit: null,
+    bufferSize: 100,
+    data: {},
+    transactions: [],
+    trades: [],
+    ...omit(args, ["candle"]),
+  };
+  return {
+    asset,
+    cash: 100,
+    commissionProvider: () => 1,
+  };
+}
+
+function testHandleOrders(args: TestArgs) {
+  const result = pipe(args, getArgs, handleOrders, (r) => ({
+    ...r,
+    asset: omit(r.asset, ["bufferSize", "data", "series", "symbol"]),
+  }));
+  expect(result).toMatchSnapshot();
+}
+
+const greenCandle: Candle = {
+  open: 50,
+  close: 60,
+  low: 40,
+  high: 70,
+  volume: 100,
+  time: 1,
+};
+
+const redCandle: Candle = {
+  open: 50,
+  close: 40,
+  low: 30,
+  high: 60,
+  volume: 100,
+  time: 1,
+};
+
+// green candle, long position
+
+it("green candle: should fill entry at bottom tail, skip sl below tail, fill tp at high", () => {
+  testHandleOrders({
+    candle: greenCandle,
+    entryOrder: { side: "buy", type: "limit", size: 1, price: 40 },
+    stopLoss: 30,
+    takeProfit: 70,
+  });
+});
+
+it("green candle: should fill entry at bottom tail, fill sl at bottom tail, skip tp at high", () => {
+  testHandleOrders({
+    candle: greenCandle,
+    entryOrder: { side: "buy", type: "limit", size: 1, price: 45 },
+    stopLoss: 40,
+    takeProfit: 70,
+  });
+});
+
+it("green candle: should fill entry at body, skip sl in body below entry, fill tp at high", () => {
+  testHandleOrders({
+    candle: greenCandle,
+    entryOrder: { side: "buy", type: "stop", size: 1, price: 55 },
+    stopLoss: 52,
+    takeProfit: 70,
+  });
+});
+
+it("green candle: should fill entry and sl immediately", () => {
+  testHandleOrders({
+    candle: greenCandle,
+    entryOrder: { side: "buy", type: "limit", size: 1, price: 55 },
+    stopLoss: 52,
+  });
+});
+
+// green candle, short position
+
+it("green candle: should fill entry", () => {
+  testHandleOrders({
+    candle: greenCandle,
+    entryOrder: { side: "sell", type: "limit", size: 1, price: 55 },
+  });
+});
+
+it("green candle: should fill short entry at body, skip tp in body below entry, fill sl at high", () => {
+  testHandleOrders({
+    candle: greenCandle,
+    entryOrder: { side: "sell", type: "limit", size: 1, price: 55 },
+    stopLoss: 70,
+    takeProfit: 52,
+  });
+});
+
+// red candle, short position
+
+it("red candle: should fill entry at top tail, skip sl above tail, fill tp at low", () => {
+  testHandleOrders({
+    candle: redCandle,
+    entryOrder: { side: "sell", type: "limit", size: 1, price: 60 },
+    stopLoss: 70,
+    takeProfit: 30,
+  });
+});
+
+it("red candle: should fill entry at top tail, fill sl at top tail, skip tp at low", () => {
+  testHandleOrders({
+    candle: redCandle,
+    entryOrder: { side: "sell", type: "limit", size: 1, price: 55 },
+    stopLoss: 60,
+    takeProfit: 30,
+  });
+});
+
+it("red candle: should fill entry at body, skip sl in body above entry, fill tp at low", () => {
+  testHandleOrders({
+    candle: redCandle,
+    entryOrder: { side: "sell", type: "stop", size: 1, price: 45 },
+    stopLoss: 48,
+    takeProfit: 30,
+  });
+});
+
+it("red candle: should fill entry and sl immediately", () => {
+  testHandleOrders({
+    candle: redCandle,
+    entryOrder: { side: "sell", type: "limit", size: 1, price: 45 },
+    stopLoss: 48,
+  });
+});
+
+// red candle, long position
+
+it("red candle: should fill entry", () => {
+  testHandleOrders({
+    candle: redCandle,
+    entryOrder: { side: "buy", type: "limit", size: 1, price: 45 },
+  });
+});
+
+it("red candle: should fill long entry at body, skip tp in body above entry, fill sl at low", () => {
+  testHandleOrders({
+    candle: redCandle,
+    entryOrder: { side: "buy", type: "limit", size: 1, price: 45 },
+    stopLoss: 30,
+    takeProfit: 48,
+  });
+});

--- a/test/backtest-smoke.test.ts
+++ b/test/backtest-smoke.test.ts
@@ -64,14 +64,14 @@ const args: CommonBacktestArgs = {
 
 const expectedStatistics: BacktestStatistics = {
   buyAndHoldProfit: 0.12410729114764989,
-  endBalance: 103.96678409210463,
+  endBalance: 106.0671231646724,
   initialBalance: 100,
   range: {
     from: 1633132800,
     to: 1633651200,
   },
-  relativeProfit: 0.03966784092104632,
-  successRate: 0.5909090909090909,
+  relativeProfit: 0.06067123164672395,
+  successRate: 0.6363636363636364,
   tradeCount: 22,
   dataInfo: {
     dataProviderName: "test-data-provider",


### PR DESCRIPTION
Making backtest order execution more realistic.

Assuming that prices move within three steps:
Green candle: open -> low -> high -> close
Red candle: open -> high -> low -> close

Orders are now filled in correct order as the limit/stop price is reached while traversing this path, and only the remaining path is considered if an order triggers or cancels other orders.

Here's how the result of the backtest smoke test changed because of this one trade, where the exit candle visits both stop loss and take profit prices:
![smoke-test-before-and-after-better-backtest-order-execution](https://user-images.githubusercontent.com/28533233/217476209-e4cd7fe5-436e-4e4e-b47c-e4660211a33d.png)
- Before (left): stop loss hit was always checked before take profit within a candle, so the trade was a loss
- After (right): based on the candle direction (downwards), it's most likely that the price visited the upper wick first before going down, so the take profit is hit before the stop loss and the trade is profitable

Here's another example of how the order execution used to work:
![ko-incorrectly-profitable](https://user-images.githubusercontent.com/28533233/217478317-d4d798a8-a2df-4c8a-8617-18e2e89184fe.png)
This trade was entered with a market buy order on candle open, and stop loss and take profit were equally far from the entry point. On the same candle where the entry took place, the logic used to be that if it's a green candle, only prices above the entry are checked for exit hits (and vice versa for red candles). So this trade was profitable. Now we check the remaining path the price takes after the entry (according to the three steps described above) in order. Since it's a green candle, the bottom tail is expected to be covered first, and stop loss to be hit before the take profit, turning the trade to a loss.

These changes make it also easier if we at some point want to add a more generic low-level API layer, that simply processes any orders the strategy function provides, without the constraints of single position/entrypoint/exitpoint per asset managed with `entryOrder`, `stopLoss` and `takeProfit`.